### PR TITLE
Added more options to github models list

### DIFF
--- a/librechat-hf.yaml
+++ b/librechat-hf.yaml
@@ -549,7 +549,32 @@ endpoints:
       apiKey: "user_provided"
       baseURL: "https://models.inference.ai.azure.com"
       models:
-        default: ["gpt-4o","Phi-3.5-MoE-instruct","Phi-3.5-mini-instruct","Phi-3.5-vision-instruct"]
+        default: [
+          "gpt-4o", 
+          "gpt-4o-mini", 
+          "o1", 
+          "o1-mini", 
+          "o1-preview", 
+          "Llama-3.3-70B-Instruct", 
+          "Llama-3.2-90B-Vision-Instruct", 
+          "Llama-3.2-11B-Vision-Instruct", 
+          "Meta-Llama-3.1-405B-Instruct", 
+          "Meta-Llama-3.1-70B-Instruct", 
+          "Meta-Llama-3.1-8B-Instruct", 
+          "Phi-4", 
+          "Phi-3.5-MoE-instruct",
+          "Phi-3.5-mini-instruct",
+          "Phi-3.5-vision-instruct",
+          "Ministral-3B", 
+          "Codestral-2501", 
+          "Mistral-large-2407", 
+          "Mistral-large", 
+          "Mistral-small", 
+          "Cohere-command-r-plus-08-2024", 
+          "Cohere-command-r-08-2024", 
+          "AI21-Jamba-1.5-Large", 
+          "AI21-Jamba-1.5-Mini"
+          ]
         fetch: false
       titleConvo: true
       titleModel: "gpt-4o-mini"


### PR DESCRIPTION
I've added the following models to the YAML

          "gpt-4o-mini", 
          "o1", 
          "o1-mini", 
          "o1-preview", 
          "Llama-3.3-70B-Instruct", 
          "Llama-3.2-90B-Vision-Instruct", 
          "Llama-3.2-11B-Vision-Instruct", 
          "Meta-Llama-3.1-405B-Instruct", 
          "Meta-Llama-3.1-70B-Instruct", 
          "Meta-Llama-3.1-8B-Instruct", 
          "Phi-4", 
          "Ministral-3B", 
          "Codestral-2501", 
          "Mistral-large-2407", 
          "Mistral-large", 
          "Mistral-small", 
          "Cohere-command-r-plus-08-2024", 
          "Cohere-command-r-08-2024", 
          "AI21-Jamba-1.5-Large", 
          "AI21-Jamba-1.5-Mini"

Previously, the only options were GPT 4o, Phi-3.5-MoE-instruct, Phi-3.5-mini-instruct, and Phi-3.5-vision-instruct