### PR TITLE
replace hyperbolic icon hosted by twimg to hyperbolic.xyz svg

### DIFF
--- a/librechat-aio.yaml
+++ b/librechat-aio.yaml
@@ -629,7 +629,7 @@ endpoints:
     # Hyperbolic
     # https://app.hyperbolic.xyz/models
     - name: 'Hyperbolic'
-      iconURL: "https://pbs.twimg.com/profile_images/1775708849707819008/1RRWsmmg_400x400.jpg"
+      iconURL: "https://app.hyperbolic.xyz/icon.svg"
       apiKey: 'user_provided'
       baseURL: 'https://api.hyperbolic.xyz/v1/'
       models:

--- a/librechat-f.yaml
+++ b/librechat-f.yaml
@@ -645,7 +645,7 @@ endpoints:
       titleConvo: true
       titleModel: "meta-llama/Meta-Llama-3.1-8B-Instruct"
       modelDisplayLabel: "Hyperbolic"
-      iconURL: "https://pbs.twimg.com/profile_images/1775708849707819008/1RRWsmmg_400x400.jpg"
+      iconURL: "https://app.hyperbolic.xyz/icon.svg"
 
     # kluster.ai
     # https://platform.kluster.ai/apikeys

--- a/librechat-hf.yaml
+++ b/librechat-hf.yaml
@@ -532,7 +532,7 @@ endpoints:
     # Hyperbolic
     # https://app.hyperbolic.xyz/models
     - name: 'Hyperbolic'
-      iconURL: "https://pbs.twimg.com/profile_images/1775708849707819008/1RRWsmmg_400x400.jpg"
+      iconURL: "https://app.hyperbolic.xyz/icon.svg"
       apiKey: 'user_provided'
       baseURL: 'https://api.hyperbolic.xyz/v1/'
       models:

--- a/librechat-rw.yaml
+++ b/librechat-rw.yaml
@@ -615,7 +615,7 @@ endpoints:
       titleConvo: true
       titleModel: "meta-llama/Meta-Llama-3.1-8B-Instruct"
       modelDisplayLabel: "Hyperbolic"
-      iconURL: "https://pbs.twimg.com/profile_images/1775708849707819008/1RRWsmmg_400x400.jpg"
+      iconURL: "https://app.hyperbolic.xyz/icon.svg"
 
     # kluster.ai
     # https://platform.kluster.ai/apikeys

--- a/librechat-test.yaml
+++ b/librechat-test.yaml
@@ -625,7 +625,7 @@ endpoints:
     # Hyperbolic
     # https://app.hyperbolic.xyz/models
     - name: 'Hyperbolic'
-      iconURL: "https://pbs.twimg.com/profile_images/1775708849707819008/1RRWsmmg_400x400.jpg"
+      iconURL: "https://app.hyperbolic.xyz/icon.svg"
       apiKey: '${HYPERBOLIC_API_KEY}'
       baseURL: 'https://api.hyperbolic.xyz/v1/'
       models:

--- a/librechat.yaml
+++ b/librechat.yaml
@@ -652,7 +652,7 @@ endpoints:
       titleConvo: true
       titleModel: "meta-llama/Meta-Llama-3.1-8B-Instruct"
       modelDisplayLabel: "Hyperbolic"
-      iconURL: "https://pbs.twimg.com/profile_images/1775708849707819008/1RRWsmmg_400x400.jpg"
+      iconURL: "https://app.hyperbolic.xyz/icon.svg"
 
     # kluster.ai
     # https://platform.kluster.ai/apikeys


### PR DESCRIPTION
This replaces the icon to one that is not inaccessible in many cases due to it being hotlinked to pbs.twimg.com
Original:
![image](https://github.com/user-attachments/assets/e93a0bf5-ffad-4020-b566-ff2a87509dc7)

Resolved:
![image](https://github.com/user-attachments/assets/7dbba3cc-0e6e-4079-8237-f0cc9aaf4b37)
