### PR TITLE
feat: add GreenPT provider

### DIFF
--- a/.github/workflows/update-models.yml
+++ b/.github/workflows/update-models.yml
@@ -50,6 +50,7 @@ jobs:
           FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GLHF_API_KEY: ${{ secrets.GLHF_API_KEY }}
+          GREENPT_API_KEY: ${{ secrets.GREENPT_API_KEY }}
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           HUGGINGFACE_TOKEN: ${{ secrets.HUGGINGFACE_TOKEN }}
           HYPERBOLIC_API_KEY: ${{ secrets.HYPERBOLIC_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Contributions are welcome!
 | FireworksAI | https://fireworks.ai/ |
 | Github Models | https://github.com |
 | glhf.chat | https://glhf.chat |
+| GreenPT | https://account.greenpt.ai/api/keys |
 | groq | https://console.groq.com/keys |
 | HuggingFace | https://huggingface.co/settings/tokens |
 | Hyperbolic | https://app.hyperbolic.xyz/ |

--- a/librechat-env-f.yaml
+++ b/librechat-env-f.yaml
@@ -1484,6 +1484,24 @@ endpoints:
       titleConvo: true
       titleModel: "gpt-4o-mini"
 
+    # GreenPT
+    # https://docs.greenpt.ai
+    # Model list: https://api.greenpt.ai/v1/models
+    - name: "GreenPT"
+      iconURL: "https://docs.greenpt.ai/logo/mark.svg"
+      apiKey: "${GREENPT_API_KEY}"
+      baseURL: "https://api.greenpt.ai/v1"
+      models:
+        default:
+          - glm-5.2
+          - kimi-k2.7-code
+        fetch: false
+      titleConvo: true
+      titleModel: "glm-5.2"
+      summarize: false
+      summaryModel: "glm-5.2"
+      modelDisplayLabel: "GreenPT"
+
     # groq
     # Model list: https://console.groq.com/settings/limits
     - name: "groq"

--- a/librechat-env-l.yaml
+++ b/librechat-env-l.yaml
@@ -1483,6 +1483,24 @@ endpoints:
       titleConvo: true
       titleModel: "gpt-4o-mini"
 
+    # GreenPT
+    # https://docs.greenpt.ai
+    # Model list: https://api.greenpt.ai/v1/models
+    - name: "GreenPT"
+      iconURL: "https://docs.greenpt.ai/logo/mark.svg"
+      apiKey: "${GREENPT_API_KEY}"
+      baseURL: "https://api.greenpt.ai/v1"
+      models:
+        default:
+          - glm-5.2
+          - kimi-k2.7-code
+        fetch: false
+      titleConvo: true
+      titleModel: "glm-5.2"
+      summarize: false
+      summaryModel: "glm-5.2"
+      modelDisplayLabel: "GreenPT"
+
     # groq
     # Model list: https://console.groq.com/settings/limits
     - name: "groq"

--- a/librechat-test.yaml
+++ b/librechat-test.yaml
@@ -1548,6 +1548,24 @@ endpoints:
       titleConvo: true
       titleModel: "current_model"
 
+    # GreenPT
+    # https://docs.greenpt.ai
+    # Model list: https://api.greenpt.ai/v1/models
+    - name: "GreenPT"
+      iconURL: "https://docs.greenpt.ai/logo/mark.svg"
+      apiKey: "${GREENPT_API_KEY}"
+      baseURL: "https://api.greenpt.ai/v1"
+      models:
+        default:
+          - glm-5.2
+          - kimi-k2.7-code
+        fetch: false
+      titleConvo: true
+      titleModel: "glm-5.2"
+      summarize: false
+      summaryModel: "glm-5.2"
+      modelDisplayLabel: "GreenPT"
+
     # groq
     # Model list: https://console.groq.com/settings/limits
     - name: "groq"

--- a/librechat-up-f.yaml
+++ b/librechat-up-f.yaml
@@ -1543,6 +1543,24 @@ endpoints:
       titleConvo: true
       titleModel: "current_model"
 
+    # GreenPT
+    # https://docs.greenpt.ai
+    # Model list: https://api.greenpt.ai/v1/models
+    - name: "GreenPT"
+      iconURL: "https://docs.greenpt.ai/logo/mark.svg"
+      apiKey: "user_provided"
+      baseURL: "https://api.greenpt.ai/v1"
+      models:
+        default:
+          - glm-5.2
+          - kimi-k2.7-code
+        fetch: false
+      titleConvo: true
+      titleModel: "glm-5.2"
+      summarize: false
+      summaryModel: "glm-5.2"
+      modelDisplayLabel: "GreenPT"
+
     # groq
     # Model list: https://console.groq.com/settings/limits
     - name: "groq"

--- a/librechat-up-l.yaml
+++ b/librechat-up-l.yaml
@@ -1552,6 +1552,24 @@ endpoints:
       titleConvo: true
       titleModel: "current_model"
 
+    # GreenPT
+    # https://docs.greenpt.ai
+    # Model list: https://api.greenpt.ai/v1/models
+    - name: "GreenPT"
+      iconURL: "https://docs.greenpt.ai/logo/mark.svg"
+      apiKey: "user_provided"
+      baseURL: "https://api.greenpt.ai/v1"
+      models:
+        default:
+          - glm-5.2
+          - kimi-k2.7-code
+        fetch: false
+      titleConvo: true
+      titleModel: "glm-5.2"
+      summarize: false
+      summaryModel: "glm-5.2"
+      modelDisplayLabel: "GreenPT"
+
     # groq
     # Model list: https://console.groq.com/settings/limits
     - name: "groq"

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -24,6 +24,9 @@ GITHUB_TOKEN=your-github-token
 # GLHF.chat - https://glhf.chat
 GLHF_API_KEY=your-glhf-key
 
+# GreenPT - https://account.greenpt.ai/api/keys
+GREENPT_API_KEY=your-greenpt-key
+
 # Groq - https://console.groq.com/keys
 GROQ_API_KEY=your-groq-key
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,6 @@
 # LibreChat YAML Configuration Manager
 
-Automated tool for maintaining LibreChat YAML configurations with up-to-date model lists from 20+ AI providers.
+Automated tool for maintaining LibreChat YAML configurations with up-to-date model lists from 21+ AI providers.
 
 ## Quick Start
 
@@ -95,6 +95,7 @@ This repository includes automated daily model updates via GitHub Actions.
    DEEPSEEK_API_KEY
    FIREWORKS_API_KEY
    GLHF_API_KEY
+   GREENPT_API_KEY
    GROQ_API_KEY
    HUGGINGFACE_TOKEN
    HYPERBOLIC_API_KEY
@@ -193,6 +194,7 @@ librechat-config-yaml/
 │   ├── fireworks.py           # Fetch models from Fireworks
 │   ├── github.py              # Fetch models from Github Models
 │   ├── glhf.py                # Fetch models from GLHF.chat
+│   ├── greenpt.py             # Fetch chat models from GreenPT
 │   ├── groq.py                # Fetch models from Groq
 │   ├── huggingface.py         # Fetch models from HuggingFace
 │   ├── hyperbolic.py          # Fetch models from Hyperbolic
@@ -235,6 +237,7 @@ The tool can update model lists from:
 - Fireworks
 - Github Models
 - GLHF.chat
+- GreenPT
 - Groq
 - HuggingFace
 - Hyperbolic
@@ -255,7 +258,7 @@ The provider scripts have been analyzed against their official API documentation
 
 | Status | Count | Providers |
 |--------|-------|-----------|
-| ✅ Validated | 11 | Cohere, DeepSeek, Fireworks, GitHub, Groq, HuggingFace, Mistral, NVIDIA, OpenRouter, TogetherAI, xAI |
+| ✅ Validated | 12 | Cohere, DeepSeek, Fireworks, GitHub, GreenPT, Groq, HuggingFace, Mistral, NVIDIA, OpenRouter, TogetherAI, xAI |
 | ⚠️ Issues Found | 4 | APIpie (minor), NanoGPT, Perplexity, SambaNova |
 | ❓ Cannot Verify | 5 | 302.AI, GLHF, Hyperbolic, Kluster, Unify |
 
@@ -277,6 +280,7 @@ These scripts have been verified against official API documentation and use prop
 | DeepSeek | [`deepseek.py`](deepseek.py) | `https://api.deepseek.com/models` |
 | Fireworks | [`fireworks.py`](fireworks.py) | `https://api.fireworks.ai/inference/v1/models` |
 | GitHub | [`github.py`](github.py) | `https://models.inference.ai.azure.com/models` |
+| GreenPT | [`greenpt.py`](providers/greenpt.py) | `https://api.greenpt.ai/v1/models` |
 | Groq | [`groq.py`](groq.py) | `https://api.groq.com/openai/v1/models` |
 | HuggingFace | [`huggingface.py`](huggingface.py) | `https://huggingface.co/api/models` |
 | Mistral | [`mistral.py`](mistral.py) | `https://api.mistral.ai/v1/models` |
@@ -317,6 +321,7 @@ Most provider scripts require valid API keys for testing:
 | DeepSeek | ✅ Yes | - |
 | Fireworks | ✅ Yes | - |
 | GitHub | ✅ Yes | Uses `GITHUB_TOKEN` |
+| GreenPT | ✅ Yes | Create a key at `account.greenpt.ai/api/keys` |
 | Groq | ✅ Yes | Free tier available |
 | HuggingFace | ✅ Yes | Free tier available |
 | Mistral | ✅ Yes | - |

--- a/scripts/providers/greenpt.py
+++ b/scripts/providers/greenpt.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import httpx
+from dotenv import load_dotenv
+from pydantic import ValidationError
+
+from .base import BaseFetcher, FetchResult, FetchStatus
+from .response_models import OpenAIModelListResponse
+
+
+NON_CHAT_MODELS = {
+    "bge-multilingual-gemma2",
+    "green-embedding",
+    "green-l",
+    "green-l-raw",
+    "green-r",
+    "green-r-raw",
+    "green-rerank",
+    "green-s",
+    "green-s-pro",
+}
+FEATURED_MODELS = ("glm-5.2", "kimi-k2.7-code")
+
+
+class GreenPTFetcher(BaseFetcher):
+    """Fetch chat models from GreenPT's OpenAI-compatible API."""
+
+    provider_name = "GreenPT"
+
+    def get_api_key(self) -> Optional[str]:
+        load_dotenv(dotenv_path=Path(__file__).parent.parent / ".env")
+        return os.getenv("GREENPT_API_KEY")
+
+    def fetch_models(self) -> FetchResult:
+        api_key = self.get_api_key()
+        if not api_key:
+            return FetchResult(
+                provider_name=self.provider_name,
+                models=[],
+                status=FetchStatus.AUTH_ERROR,
+                error_message="GREENPT_API_KEY not set",
+            )
+
+        try:
+            response = self._http_get(
+                "https://api.greenpt.ai/v1/models",
+                headers={
+                    "accept": "application/json",
+                    "Authorization": f"Bearer {api_key}",
+                },
+            )
+            try:
+                validated = OpenAIModelListResponse.model_validate(response.json())
+            except ValidationError as error:
+                return FetchResult(
+                    provider_name=self.provider_name,
+                    models=[],
+                    status=FetchStatus.PARSE_ERROR,
+                    error_message=str(error),
+                )
+
+            models = [
+                entry.id
+                for entry in validated.data
+                if entry.id not in NON_CHAT_MODELS
+                and "embedding" not in entry.id.lower()
+                and "rerank" not in entry.id.lower()
+            ]
+            if not models:
+                return FetchResult(
+                    provider_name=self.provider_name,
+                    models=[],
+                    status=FetchStatus.EMPTY,
+                    error_message="No chat models returned after filtering",
+                )
+            return FetchResult(
+                provider_name=self.provider_name,
+                models=models,
+                status=FetchStatus.SUCCESS,
+            )
+        except httpx.HTTPStatusError as error:
+            status = (
+                FetchStatus.AUTH_ERROR
+                if error.response.status_code in (401, 403)
+                else FetchStatus.NETWORK_ERROR
+            )
+            return FetchResult(
+                provider_name=self.provider_name,
+                models=[],
+                status=status,
+                error_message=str(error),
+            )
+        except httpx.HTTPError as error:
+            return FetchResult(
+                provider_name=self.provider_name,
+                models=[],
+                status=FetchStatus.NETWORK_ERROR,
+                error_message=str(error),
+            )
+
+    def post_process(self, models: list[str]) -> list[str]:
+        unique_models = set(models)
+        featured = [model for model in FEATURED_MODELS if model in unique_models]
+        return featured + sorted(unique_models - set(featured))

--- a/scripts/tests/test_providers.py
+++ b/scripts/tests/test_providers.py
@@ -133,6 +133,70 @@ class TestGroqFetcher:
 
 
 # ---------------------------------------------------------------------------
+# GreenPT
+# ---------------------------------------------------------------------------
+
+class TestGreenPTFetcher:
+    def _make(self):
+        from providers.greenpt import GreenPTFetcher
+        return GreenPTFetcher()
+
+    def test_greenpt_provider_name(self):
+        from providers.greenpt import GreenPTFetcher
+        assert GreenPTFetcher.provider_name == "GreenPT"
+
+    def test_greenpt_no_api_key(self, monkeypatch):
+        monkeypatch.delenv("GREENPT_API_KEY", raising=False)
+        with patch("providers.greenpt.load_dotenv"):
+            result = self._make().fetch_models()
+
+        assert result.status == FetchStatus.AUTH_ERROR
+        assert "GREENPT_API_KEY" in result.error_message
+
+    def test_greenpt_fetches_chat_models(self, monkeypatch):
+        from providers.greenpt import GreenPTFetcher
+        monkeypatch.setenv("GREENPT_API_KEY", "test-key")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {"id": "glm-5.2"},
+                {"id": "kimi-k2.7-code"},
+                {"id": "green-embedding"},
+                {"id": "green-rerank"},
+                {"id": "green-s-pro"},
+            ]
+        }
+
+        with patch("providers.greenpt.load_dotenv"), \
+             patch.object(GreenPTFetcher, "_http_get", return_value=mock_resp):
+            result = self._make().run()
+
+        assert result.status == FetchStatus.SUCCESS
+        assert result.models == ["glm-5.2", "kimi-k2.7-code"]
+
+    def test_greenpt_post_process_features_flagships(self):
+        models = ["other-model", "kimi-k2.7-code", "glm-5.2", "other-model"]
+        assert self._make().post_process(models) == [
+            "glm-5.2",
+            "kimi-k2.7-code",
+            "other-model",
+        ]
+
+    def test_greenpt_fetch_malformed_response(self, monkeypatch):
+        from providers.greenpt import GreenPTFetcher
+        monkeypatch.setenv("GREENPT_API_KEY", "test-key")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"models": []}
+
+        with patch("providers.greenpt.load_dotenv"), \
+             patch.object(GreenPTFetcher, "_http_get", return_value=mock_resp):
+            result = self._make().fetch_models()
+
+        assert result.status == FetchStatus.PARSE_ERROR
+        assert "data" in result.error_message
+
+
+# ---------------------------------------------------------------------------
 # 302AI
 # ---------------------------------------------------------------------------
 
@@ -1206,7 +1270,7 @@ def _reload_all_providers():
         "providers.sambanova", "providers.perplexity", "providers.togetherai",
         "providers.cohere", "providers.unify", "providers.huggingface",
         "providers.ai302", "providers.deepseek", "providers.fireworks",
-        "providers.glhf", "providers.kluster", "providers.mistral",
+        "providers.glhf", "providers.greenpt", "providers.kluster", "providers.mistral",
         "providers.hyperbolic", "providers.xai",
     ]
 
@@ -1218,12 +1282,12 @@ def _reload_all_providers():
 
 
 class TestRegistration:
-    def test_all_20_providers_registered(self):
-        """All 20 providers must be discoverable."""
+    def test_all_21_providers_registered(self):
+        """All 21 providers must be discoverable."""
         registry = _reload_all_providers()
         expected = {
             "302AI", "APIpie", "cohere", "deepseek", "Fireworks",
-            "Github Models", "glhf.chat", "groq", "HuggingFace",
+            "Github Models", "glhf.chat", "GreenPT", "groq", "HuggingFace",
             "Hyperbolic", "Kluster", "Mistral", "NanoGPT", "Nvidia",
             "OpenRouter", "Perplexity", "SambaNova", "together.ai",
             "Unify", "xai",
@@ -1235,7 +1299,7 @@ class TestRegistration:
 
     def test_registry_count(self):
         registry = _reload_all_providers()
-        assert len(registry) == 20
+        assert len(registry) == 21
 
 
 class TestNoDuplicates:
@@ -1274,7 +1338,7 @@ class TestAllProviderNames:
         # These are the exact YAML endpoint names from the config files
         expected_names = {
             "302AI", "APIpie", "cohere", "deepseek", "Fireworks",
-            "Github Models", "glhf.chat", "groq", "HuggingFace",
+            "Github Models", "glhf.chat", "GreenPT", "groq", "HuggingFace",
             "Hyperbolic", "Kluster", "Mistral", "NanoGPT", "Nvidia",
             "OpenRouter", "Perplexity", "SambaNova", "together.ai",
             "Unify", "xai",


### PR DESCRIPTION
## Summary

GreenPT is a European AI provider with an OpenAI-compatible API, optimized infrastructure, and data centers powered by 100% renewable energy.

This adds GreenPT to LibreChat's official configuration collection:

- provider entries in all five `librechat-*.yaml` variants
- environment-key and `user_provided` authentication variants
- the official GreenPT logo and `https://api.greenpt.ai/v1` base URL
- `glm-5.2` and the coding-focused `kimi-k2.7-code` as the initial featured models
- an authenticated `/v1/models` fetcher for daily model-list updates

The fetcher keeps `glm-5.2` and `kimi-k2.7-code` first, and excludes embedding, rerank, and speech models because LibreChat's custom endpoint list is used for chat models. This prevents non-chat model IDs from appearing in the chat picker.

## Type of change

- [x] Provider added / removed / renamed
- [ ] Model list curated (no script change)
- [x] Fetcher script change (`scripts/providers/*.py`)
- [x] Pipeline / workflow change (`.github/workflows/*`)
- [ ] Schema bump / preamble change (top-level keys)
- [x] Documentation only

## Checklist

- [x] The provider entry exists in all five config files, a fetcher exists under `scripts/providers/`, and the API-key table is updated.
- [x] `cd scripts && pytest -q` passes locally: 237 tests.
- [x] `cd scripts && npm ci && cd .. && node scripts/validate_config.mjs` passes for all five YAML files.
- [ ] The CI `Validate YAML` workflow is green.
- [x] No secrets or deployment-specific configuration are included.

## Related issues

No existing GreenPT provider issue or pull request was found.
